### PR TITLE
feat: NR-417687 ns1 workaround 429 too many requests

### DIFF
--- a/docs/tutorials/ns1.md
+++ b/docs/tutorials/ns1.md
@@ -184,6 +184,8 @@ The TTL annotation can be used to configure the TTL on DNS records managed by Ex
 
 ExternalDNS uses the hostname annotation to determine which services should be registered with DNS. Removing the hostname annotation will cause ExternalDNS to remove the corresponding DNS records.
 
+**Note:** The NS1 provider now includes built-in handling for API rate limiting. If the NS1 API returns a "429 Too Many Requests" response, ExternalDNS will automatically retry the operation. This improves reliability when managing DNS records under heavy usage or automation.
+
 ### Create the deployment and service
 
 ```
@@ -195,6 +197,8 @@ Depending on where you run your service, it may take some time for your cloud pr
 ## Verifying NS1 DNS records
 
 Use the NS1 portal or API to verify that the A record for your domain shows the external IP address of the services.
+
+If you experience temporary delays in DNS record updates, it may be due to NS1 API rate limiting. ExternalDNS will retry automatically, and changes should be applied once the rate limit is lifted.
 
 ## Cleanup
 

--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -247,8 +247,6 @@ func (p *NS1Provider) ns1SubmitChanges(changes []*ns1Change) error {
 				err = withRetries(func() (*http.Response, error) {
 					return p.client.UpdateRecord(record)
 				})
-			default:
-				return fmt.Errorf("unsupported action: %s", change.Action)
 			}
 
 			if err != nil {


### PR DESCRIPTION
### Summary

This pull request implements a workaround for the NS1 DNS provider to handle HTTP 429 "Too Many Requests" responses gracefully. When the NS1 API rate limits requests, the provider now retries the operation 5 times (default), improving reliability and avoiding exiting the application with the code `1`.

### Changes

- **NS1 Provider:**  
  - Added retry logic for API calls that receive a 429 response from NS1.
  - Ensured that the provider will attempt the operation again after a rate limit error, rather than failing immediately.
  - A jitter is added to avoid hammering.
  - Added `maxBackoff` variable in order to prevent excessive delays in case of persistent rate limiting. 
  - Updated the ns1.md Readme file according to the changes.

- **Unit Tests:**  
  - Added a new test (`TestNS1ApplyChangesRateLimitRetry`) to verify that the provider retries on a 429 error and eventually succeeds.
  - Added another test(`TestNS1ApplyChangesRateLimitExceeded`) to verify that the provider eventually fails if the number of retries is more than `maxRetries`.
  - Introduced a mock client (`MockNS1RateLimitAndRetry`) to simulate rate limiting and successful retry behavior.

### Motivation

NS1's API enforces rate limits, which can cause operations to fail with HTTP 429 errors. This workaround ensures that the provider is resilient to such errors by retrying, as requested in [NR-417687](https://new-relic.atlassian.net/browse/NR-417687).

### Testing

- Checked that the new unit tests pass (`go test -race -coverprofile=profile.cov ./provider/ns1/`).
- The new test confirms that the retry logic is triggered and works as expected.

---

**Related Issue:** [NR-417687](https://new-relic.atlassian.net/browse/NR-417687)  
**Type:** Feature/Workaround  
**Area:** NS1 Provider, Reliability

Please review and provide feedback.