### PR TITLE
feat: NR-417687 ns1 workaround 429 too many requests for zones

### DIFF
--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -272,7 +272,13 @@ func (p *NS1Provider) ns1SubmitChanges(changes []*ns1Change) error {
 // Zones returns the list of hosted zones.
 func (p *NS1Provider) zonesFiltered() ([]*dns.Zone, error) {
 	// TODO handle Header Codes
-	zones, _, err := p.client.ListZones()
+	zones := []*dns.Zone{}
+	_, err := withRetries(func() (*http.Response, error) {
+		var apiErr error
+		var r *http.Response
+		zones, r, apiErr = p.client.ListZones()
+		return r, apiErr
+	}, p.maxRetries, p.initialBackoff, p.maxBackoff)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary

This pull request introduces a workaround for handling HTTP 429 "Too Many Requests" errors when listing zones from the NS1 provider. The API rate limits cause zone listing operations to fail intermittently leading to `exit 1` error and to the restart of a pod.

### Details

- **Retry Logic:**  
  The `zonesFiltered` method in the NS1 provider now uses the `withRetries` function to automatically retry API calls to NS1 when a 429 status code is encountered. This helps to get rid of the next error messages:
```
level=fatal msg="GET https://api.nsone.net/v1/zones: 429 Too Many Requests"
```
- **Exponential Backoff:**  
  The retry mechanism uses exponential backoff with jitter, configurable via provider parameters, to avoid overwhelming the API and to increase the likelihood of successful requests.
- **Testing:**  
  New unit tests have been added to verify the retry logic, including scenarios where the API eventually succeeds and where it continues to return 429 errors until retries are exhausted.

### Impact

- Improves reliability and resilience of the NS1 provider against rate limiting.
- No breaking changes to the public API.

---

**Closes:** [NR-417687 ](https://new-relic.atlassian.net/browse/NR-417687) 
**Related:** NS1 provider, rate limiting, 429 error handling
