### PR TITLE
feat: NR-417687 ns1 workaround 429 too many requests for get a single zone

### DIFF
--- a/provider/ns1/ns1.go
+++ b/provider/ns1/ns1.go
@@ -46,11 +46,7 @@ const (
 	ns1DefaultTTL = 10
 	// maxRetries is the number of retries for rate limited requests
 	maxRetries = 5
-	// initialBackoff is the initial backoff duration for rate limited requests
-	initialBackoff = 1 * time.Second
 	// maxBackoff is the maximum backoff duration for rate limited requests.
-	// The backoff will double each time until it reaches this value.
-	// Added in order to prevent excessive delays in case of persistent rate limiting.
 	maxBackoff = 10 * time.Second
 )
 
@@ -106,14 +102,11 @@ type NS1Config struct {
 // NS1Provider is the NS1 provider
 type NS1Provider struct {
 	provider.BaseProvider
-	client         NS1DomainClient
-	domainFilter   endpoint.DomainFilter
-	zoneIDFilter   provider.ZoneIDFilter
-	dryRun         bool
-	minTTLSeconds  int
-	maxRetries     int
-	initialBackoff time.Duration
-	maxBackoff     time.Duration
+	client        NS1DomainClient
+	domainFilter  endpoint.DomainFilter
+	zoneIDFilter  provider.ZoneIDFilter
+	dryRun        bool
+	minTTLSeconds int
 }
 
 // NewNS1Provider creates a new NS1 Provider
@@ -154,13 +147,10 @@ func newNS1ProviderWithHTTPClient(config NS1Config, client *http.Client) (*NS1Pr
 	apiClient := api.NewClient(client, clientArgs...)
 
 	provider := &NS1Provider{
-		client:         NS1DomainService{apiClient},
-		domainFilter:   config.DomainFilter,
-		zoneIDFilter:   config.ZoneIDFilter,
-		minTTLSeconds:  config.MinTTLSeconds,
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client:        NS1DomainService{apiClient},
+		domainFilter:  config.DomainFilter,
+		zoneIDFilter:  config.ZoneIDFilter,
+		minTTLSeconds: config.MinTTLSeconds,
 	}
 	return provider, nil
 }

--- a/provider/ns1/ns1_test.go
+++ b/provider/ns1/ns1_test.go
@@ -129,13 +129,10 @@ func (m *MockNS1ListZonesFail) ListZones() ([]*dns.Zone, *http.Response, error) 
 
 func TestNS1Records(t *testing.T) {
 	provider := &NS1Provider{
-		client:         &MockNS1DomainClient{},
-		domainFilter:   endpoint.NewDomainFilter([]string{"foo.com."}),
-		zoneIDFilter:   provider.NewZoneIDFilter([]string{""}),
-		minTTLSeconds:  3600,
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client:        &MockNS1DomainClient{},
+		domainFilter:  endpoint.NewDomainFilter([]string{"foo.com."}),
+		zoneIDFilter:  provider.NewZoneIDFilter([]string{""}),
+		minTTLSeconds: 3600,
 	}
 	ctx := context.Background()
 
@@ -169,12 +166,9 @@ func TestNewNS1Provider(t *testing.T) {
 
 func TestNS1Zones(t *testing.T) {
 	provider := &NS1Provider{
-		client:         &MockNS1DomainClient{},
-		domainFilter:   endpoint.NewDomainFilter([]string{"foo.com."}),
-		zoneIDFilter:   provider.NewZoneIDFilter([]string{""}),
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client:       &MockNS1DomainClient{},
+		domainFilter: endpoint.NewDomainFilter([]string{"foo.com."}),
+		zoneIDFilter: provider.NewZoneIDFilter([]string{""}),
 	}
 
 	zones, err := provider.zonesFiltered()
@@ -204,13 +198,10 @@ func TestNS1BuildRecord(t *testing.T) {
 	}
 
 	provider := &NS1Provider{
-		client:         &MockNS1DomainClient{},
-		domainFilter:   endpoint.NewDomainFilter([]string{"foo.com."}),
-		zoneIDFilter:   provider.NewZoneIDFilter([]string{""}),
-		minTTLSeconds:  300,
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client:        &MockNS1DomainClient{},
+		domainFilter:  endpoint.NewDomainFilter([]string{"foo.com."}),
+		zoneIDFilter:  provider.NewZoneIDFilter([]string{""}),
+		minTTLSeconds: 300,
 	}
 
 	record := provider.ns1BuildRecord("foo.com", change)
@@ -236,10 +227,7 @@ func TestNS1BuildRecord(t *testing.T) {
 func TestNS1ApplyChanges(t *testing.T) {
 	changes := &plan.Changes{}
 	provider := &NS1Provider{
-		client:         &MockNS1DomainClient{},
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client: &MockNS1DomainClient{},
 	}
 	changes.Create = []*endpoint.Endpoint{
 		{DNSName: "new.foo.com", Targets: endpoint.Targets{"target"}},
@@ -288,10 +276,7 @@ func TestNewNS1Changes(t *testing.T) {
 
 func TestNewNS1ChangesByZone(t *testing.T) {
 	provider := &NS1Provider{
-		client:         &MockNS1DomainClient{},
-		maxRetries:     maxRetries,
-		initialBackoff: initialBackoff,
-		maxBackoff:     maxBackoff,
+		client: &MockNS1DomainClient{},
 	}
 	zones, _ := provider.zonesFiltered()
 	changeSets := []*ns1Change{


### PR DESCRIPTION
### Summary

This pull request implements a workaround for HTTP 429 "Too Many Requests" errors specifically in the `GetZone` method of the NS1 provider. Basically, implementing the same retry mechanism for all existing methods, which interact with NS1.

Example error from the logs:

```
time="2025-06-23T01:20:40Z" level=fatal msg="GET https://api.nsone.net/v1/zones/jc1a.cell.us.nr-ops.net: 429 Too Many Requests"
```

### Details

- **Retry Logic for GetZone:**  
  - The `GetZone` method now uses the existing `withRetries` function to automatically retry API calls that receive a 429 response.
- **Unit Tests:**  
  - Added unit tests for the `GetZone` retry logic.
  - Tests verify that the method succeeds after transient 429 errors and fails gracefully after exceeding the maximum number of retries.

### Impact

- Improves reliability of the NS1 provider when faced with API rate limiting.
- Ensures `GetZone` operations are more resilient to transient errors.
- Adds comprehensive tests for the new retry logic.
- No breaking changes to the public API.
